### PR TITLE
Have i voted

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ curl -X POST localhost:9013/internal/vote/clear_all
 ```
 
 
+### Have I Voted
+
+A user can find out if he has voted for a list of polls.
+
+```
+curl localhost:9013/system/vote/voted?ids=1,2,3
+```
+
+The responce is a json-object in the form like this:
+
+```
+{
+  "1":true,
+  "2":false,
+  "3":true
+}
+```
+
+
 ## Configuration
 
 ### Environment variables

--- a/internal/backends/memory/memory.go
+++ b/internal/backends/memory/memory.go
@@ -113,6 +113,19 @@ func (b *Backend) ClearAll(ctx context.Context) error {
 	return nil
 }
 
+// VotedPolls tells for a list of poll IDs if the given userID has already
+// voted.
+func (b *Backend) VotedPolls(ctx context.Context, pollIDs []int, userID int) (map[int]bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	out := make(map[int]bool)
+	for _, id := range pollIDs {
+		out[id] = b.voted[id][userID]
+	}
+	return out, nil
+}
+
 // AssertUserHasVoted is a method for the tests to check, if a user has voted.
 func (b *Backend) AssertUserHasVoted(t *testing.T, pollID, userID int) {
 	t.Helper()

--- a/internal/backends/postgres/postgres.go
+++ b/internal/backends/postgres/postgres.go
@@ -276,6 +276,12 @@ func (b *Backend) ClearAll(ctx context.Context) error {
 	return nil
 }
 
+// VotedPolls tells for a list of poll IDs if the given userID has already
+// voted.
+func (b *Backend) VotedPolls(ctx context.Context, pollIDs []int, userID int) (map[int]bool, error) {
+	return nil, errors.New("TODO")
+}
+
 // ContinueOnTransactionError runs the given many times until is does not return
 // an transaction error. Also stopes, when the given context is canceled.
 func continueOnTransactionError(ctx context.Context, f func() error) error {

--- a/internal/backends/postgres/postgres.go
+++ b/internal/backends/postgres/postgres.go
@@ -278,8 +278,39 @@ func (b *Backend) ClearAll(ctx context.Context) error {
 
 // VotedPolls tells for a list of poll IDs if the given userID has already
 // voted.
-func (b *Backend) VotedPolls(ctx context.Context, pollIDs []int, userID int) (map[int]bool, error) {
-	return nil, errors.New("TODO")
+func (b *Backend) VotedPolls(ctx context.Context, pollIDs []int, userID int) (out map[int]bool, err error) {
+	log.Debug("SQL: Begin voted polls")
+	defer func() {
+		log.Debug("SQL: Begin voted polls with error: %v", err)
+	}()
+
+	sql := `
+	SELECT id, user_ids
+	FROM poll
+	WHERE id = ANY ($1);
+	`
+
+	rows, err := b.pool.Query(ctx, sql, pollIDs)
+	if err != nil {
+		return nil, fmt.Errorf("fetching user_ids from poll objects: %w", err)
+	}
+
+	out = make(map[int]bool, len(pollIDs))
+
+	for rows.Next() {
+		var pid int
+		var uIDs userIDs
+		if err := rows.Scan(&pid, &uIDs); err != nil {
+			return nil, fmt.Errorf("parsind row: %w", err)
+		}
+		out[pid] = uIDs.contains(int32(userID))
+	}
+
+	// Add values for non existing polls
+	for _, id := range pollIDs {
+		out[id] = out[id] || false
+	}
+	return out, nil
 }
 
 // ContinueOnTransactionError runs the given many times until is does not return
@@ -322,7 +353,6 @@ func (u *userIDs) Scan(src interface{}) error {
 	}
 	*u = ints
 	return nil
-
 }
 
 func (u userIDs) Value() (driver.Value, error) {
@@ -348,6 +378,13 @@ func (u *userIDs) add(userID int32) error {
 	ints = append(ints[:idx], append([]int32{userID}, ints[idx:]...)...)
 	*u = ints
 	return nil
+}
+
+// contains returns true if the userID is contains the list of userIDs.
+func (u *userIDs) contains(userID int32) bool {
+	ints := []int32(*u)
+	idx := sort.Search(len(ints), func(i int) bool { return ints[i] >= userID })
+	return idx < len(ints) && ints[idx] == userID
 }
 
 type doesNotExistError struct {

--- a/internal/backends/redis/redis.go
+++ b/internal/backends/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -235,6 +236,12 @@ func (b *Backend) ClearAll(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// VotedPolls tells for a list of poll IDs if the given userID has already
+// voted.
+func (b *Backend) VotedPolls(ctx context.Context, pollIDs []int, userID int) (map[int]bool, error) {
+	return nil, errors.New("TODO")
 }
 
 type doesNotExistError struct {

--- a/internal/backends/test/test.go
+++ b/internal/backends/test/test.go
@@ -242,6 +242,21 @@ func Backend(t *testing.T, backend vote.Backend) {
 	})
 
 	pollID++
+	t.Run("VotedPolls", func(t *testing.T) {
+		backend.Start(context.Background(), pollID)
+		backend.Vote(context.Background(), pollID, 5, []byte("my vote"))
+
+		voted, err := backend.VotedPolls(context.Background(), []int{pollID, pollID + 1}, 5)
+		if err != nil {
+			t.Fatalf("VotedPolls returned unexpected error: %v", err)
+		}
+
+		if len(voted) != 2 || !voted[pollID] || voted[pollID+1] {
+			t.Errorf("VotedPolls returned %v, expected {%d: true, %d: false}", voted, pollID, pollID+1)
+		}
+	})
+
+	pollID++
 	t.Run("Concurrency", func(t *testing.T) {
 		t.Run("Many Votes", func(t *testing.T) {
 			count := 100

--- a/internal/vote/http.go
+++ b/internal/vote/http.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/OpenSlides/openslides-vote-service/internal/log"
 )
@@ -25,12 +26,12 @@ func handleCreate(mux *http.ServeMux, create creater) {
 		httpPathInternal+"/create",
 		func(w http.ResponseWriter, r *http.Request) {
 			log.Debug("Receive create request: %v", r)
+			w.Header().Set("Content-Type", "application/json")
+
 			if r.Method != "POST" {
 				http.Error(w, MessageError{ErrInvalid, "Only POST requests are allowed"}.Error(), 405)
 				return
 			}
-
-			w.Header().Set("Content-Type", "application/json")
 
 			id, err := pollID(r)
 			if err != nil {
@@ -57,12 +58,12 @@ func handleStop(mux *http.ServeMux, stop stopper) {
 		httpPathInternal+"/stop",
 		func(w http.ResponseWriter, r *http.Request) {
 			log.Debug("Receive stop request: %v", r)
+			w.Header().Set("Content-Type", "application/json")
+
 			if r.Method != "POST" {
 				http.Error(w, MessageError{ErrInvalid, "Only POST requests are allowed"}.Error(), 405)
 				return
 			}
-
-			w.Header().Set("Content-Type", "application/json")
 
 			id, err := pollID(r)
 			if err != nil {
@@ -87,12 +88,12 @@ func handleClear(mux *http.ServeMux, clear clearer) {
 		httpPathInternal+"/clear",
 		func(w http.ResponseWriter, r *http.Request) {
 			log.Debug("Receive clear request: %v", r)
+			w.Header().Set("Content-Type", "application/json")
+
 			if r.Method != "POST" {
 				http.Error(w, MessageError{ErrInvalid, "Only POST requests are allowed"}.Error(), 405)
 				return
 			}
-
-			w.Header().Set("Content-Type", "application/json")
 
 			id, err := pollID(r)
 			if err != nil {
@@ -117,12 +118,12 @@ func handleClearAll(mux *http.ServeMux, clear clearAller) {
 		httpPathInternal+"/clear_all",
 		func(w http.ResponseWriter, r *http.Request) {
 			log.Debug("Receive clear request: %v", r)
+			w.Header().Set("Content-Type", "application/json")
+
 			if r.Method != "POST" {
 				http.Error(w, MessageError{ErrInvalid, "Only POST requests are allowed"}.Error(), 405)
 				return
 			}
-
-			w.Header().Set("Content-Type", "application/json")
 
 			if err := clear.ClearAll(r.Context()); err != nil {
 				handleError(w, err, true)
@@ -146,12 +147,12 @@ func handleVote(mux *http.ServeMux, vote voter, auth authenticater) {
 		httpPathExternal,
 		func(w http.ResponseWriter, r *http.Request) {
 			log.Debug("Receive vote request: %v", r)
+			w.Header().Set("Content-Type", "application/json")
+
 			if r.Method != "POST" {
 				http.Error(w, MessageError{ErrInvalid, "Only POST requests are allowed"}.Error(), 405)
 				return
 			}
-
-			w.Header().Set("Content-Type", "application/json")
 
 			ctx, err := auth.Authenticate(w, r)
 			if err != nil {
@@ -172,6 +173,48 @@ func handleVote(mux *http.ServeMux, vote voter, auth authenticater) {
 			}
 
 			if err := vote.Vote(ctx, id, uid, r.Body); err != nil {
+				handleError(w, err, false)
+				return
+			}
+		},
+	)
+}
+
+type votedPollser interface {
+	VotedPolls(ctx context.Context, pollIDs []int, requestUser int, w io.Writer) error
+}
+
+func handleVoted(mux *http.ServeMux, voted votedPollser, auth authenticater) {
+	mux.HandleFunc(
+		httpPathExternal+"/voted",
+		func(w http.ResponseWriter, r *http.Request) {
+			log.Debug("Receive clear request: %v", r)
+			w.Header().Set("Content-Type", "application/json")
+
+			if r.Method != "GET" {
+				http.Error(w, MessageError{ErrInvalid, "Only GET requests are allowed"}.Error(), 405)
+				return
+			}
+
+			ctx, err := auth.Authenticate(w, r)
+			if err != nil {
+				handleError(w, err, false)
+				return
+			}
+
+			uid := auth.FromContext(ctx)
+			if uid == 0 {
+				http.Error(w, MessageError{ErrNotAllowed, "Anonymous user can not vote"}.Error(), 401)
+				return
+			}
+
+			pollIDs, err := pollsID(r)
+			if err != nil {
+				http.Error(w, MessageError{ErrInvalid, err.Error()}.Error(), 400)
+				return
+			}
+
+			if err := voted.VotedPolls(ctx, pollIDs, uid, w); err != nil {
 				handleError(w, err, false)
 				return
 			}
@@ -202,6 +245,21 @@ func pollID(r *http.Request) (int, error) {
 	}
 
 	return id, nil
+}
+
+func pollsID(r *http.Request) ([]int, error) {
+	rawIDs := strings.Split(r.URL.Query().Get("ids"), ",")
+
+	ids := make([]int, len(rawIDs))
+	for i, rawID := range rawIDs {
+		id, err := strconv.Atoi(rawID)
+		if err != nil {
+			return nil, fmt.Errorf("%dth id invalid. Expected int, got %s", i, rawID)
+		}
+		ids[i] = id
+	}
+
+	return ids, nil
 }
 
 func handleError(w http.ResponseWriter, err error, internal bool) {

--- a/internal/vote/http.go
+++ b/internal/vote/http.go
@@ -188,7 +188,7 @@ func handleVoted(mux *http.ServeMux, voted votedPollser, auth authenticater) {
 	mux.HandleFunc(
 		httpPathExternal+"/voted",
 		func(w http.ResponseWriter, r *http.Request) {
-			log.Debug("Receive clear request: %v", r)
+			log.Debug("Receive voted request: %v", r)
 			w.Header().Set("Content-Type", "application/json")
 
 			if r.Method != "GET" {

--- a/internal/vote/run.go
+++ b/internal/vote/run.go
@@ -67,6 +67,7 @@ func Run(ctx context.Context, environment []string, getSecret func(name string) 
 	handleClear(mux, service)
 	handleClearAll(mux, service)
 	handleVote(mux, service, auth)
+	handleVoted(mux, service, auth)
 	handleHealth(mux)
 
 	listenAddr := ":" + env["VOTE_PORT"]

--- a/internal/vote/run_test.go
+++ b/internal/vote/run_test.go
@@ -76,6 +76,7 @@ func TestRun(t *testing.T) {
 			"/internal/vote/stop",
 			"/internal/vote/clear",
 			"/system/vote",
+			"/system/vote/voted",
 			"/system/vote/health",
 		} {
 			t.Run(path, func(t *testing.T) {

--- a/internal/vote/vote.go
+++ b/internal/vote/vote.go
@@ -307,6 +307,11 @@ func (v *Vote) Vote(ctx context.Context, pollID, requestUser int, r io.Reader) (
 	return nil
 }
 
+// VotedPolls tells, on which the requestUser has already voted.
+func (v *Vote) VotedPolls(ctx context.Context, pollIDs []int, requestUser int, w io.Writer) error {
+	return errors.New("TODO")
+}
+
 // Backend is a storage for the poll options.
 type Backend interface {
 	// Start opens the poll for votes. To start a poll that is already started

--- a/internal/vote/vote.go
+++ b/internal/vote/vote.go
@@ -308,8 +308,33 @@ func (v *Vote) Vote(ctx context.Context, pollID, requestUser int, r io.Reader) (
 }
 
 // VotedPolls tells, on which the requestUser has already voted.
-func (v *Vote) VotedPolls(ctx context.Context, pollIDs []int, requestUser int, w io.Writer) error {
-	return errors.New("TODO")
+func (v *Vote) VotedPolls(ctx context.Context, pollIDs []int, requestUser int, w io.Writer) (err error) {
+	log.Debug("Receive voted event for polls %v from user %d", pollIDs, requestUser)
+	defer func() {
+		log.Debug("End voted event with error: %v", err)
+	}()
+
+	polls, err := v.fastBackend.VotedPolls(ctx, pollIDs, requestUser)
+	if err != nil {
+		return fmt.Errorf("getting polls from fas backend: %w", err)
+	}
+	log.Debug("polls from fast backend: %v", polls)
+
+	longPolls, err := v.longBackend.VotedPolls(ctx, pollIDs, requestUser)
+	if err != nil {
+		return fmt.Errorf("getting polls from long backend: %w", err)
+	}
+	log.Debug("polls from long backend: %v", polls)
+
+	for p, v := range longPolls {
+		polls[p] = polls[p] || v
+	}
+	log.Debug("Combined polls: %v", err)
+
+	if err := json.NewEncoder(w).Encode(polls); err != nil {
+		return fmt.Errorf("encoding polls %v: %w", polls, err)
+	}
+	return nil
 }
 
 // Backend is a storage for the poll options.
@@ -338,6 +363,10 @@ type Backend interface {
 
 	// ClearAll removes all data from the backend.
 	ClearAll(ctx context.Context) error
+
+	// VotedPolls tells for a list of poll IDs if the given userID has already
+	// voted.
+	VotedPolls(ctx context.Context, pollIDs []int, userID int) (map[int]bool, error)
 
 	fmt.Stringer
 }

--- a/internal/vote/vote_test.go
+++ b/internal/vote/vote_test.go
@@ -833,3 +833,21 @@ func TestVoteWeight(t *testing.T) {
 		})
 	}
 }
+
+func TestVotedPolls(t *testing.T) {
+	backend := memory.New()
+	v := vote.New(backend, backend, nil)
+	backend.Start(context.Background(), 1)
+	backend.Vote(context.Background(), 1, 5, []byte(`"Y"`))
+	buf := new(bytes.Buffer)
+
+	if err := v.VotedPolls(context.Background(), []int{1, 2}, 5, buf); err != nil {
+		t.Fatalf("VotedPolls() returned unexected error: %v", err)
+	}
+
+	expect := `{"1":true,"2":false}` + "\n"
+	if buf.String() != expect {
+		t.Errorf("VotedPolls() wrote %v, expected %s", buf.String(), expect)
+	}
+
+}


### PR DESCRIPTION
This adds the `/system/vote/voted` url.

The implementation of the redis backend is not atomic. This means you get the information for a list of polls if you have voted, but there could be other redis-commands in between. I think this is ok for this situation.

The current implementation works for any poll-state. So a user can ask even for non started or stopped polls. If a pollID does not exist, then the same result is returned as if the poll exists but the user can not vote.

This url also works on stopped polls, until the backend called the clear-url. So a user gets `true` for a stopped poll where he as voted but `false` for a cleared poll.

An alternative would be to switch the question. From "have i voted" to "can I vote". This url would return true only for polls that are in the started state and the user has not already voted.

For example:
Poll 1 is not started yet. Poll 2 and 3 are started. Poll 4 is stopped. Poll 5 is stopped and cleared.
The user has voted on Poll 3,4 and 5

The current implementation returns for the request
`/system/vote/voted?ids=1,2,3,4,5`
```
{
  "1":false,
  "2":false,
  "3":true,
  "4":true,
  "5":false
}
```

The alternativ implementation would return
`/system/vote/can_vote?ids=1,2,3,4,5`
```
{
  "1":false,
  "2":true,
  "3":false,
  "4":false,
  "5":false
}
```

What do you think. Should I change the "have I voted" to a "can I vote" url?