### PR TITLE
Use debian bookworm images

### DIFF
--- a/system_test/docker-compose.yml
+++ b/system_test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   postgres:
-    image: postgres:13
+    image: postgres:15
     environment:
       - POSTGRES_USER=openslides
       - POSTGRES_PASSWORD=openslides


### PR DESCRIPTION
Apart from debian being sensical on it's own, buster packages include postgres software for v11 - bookworm does for v15.