### PR TITLE
Make a copy of voted before releasing the mutex

### DIFF
--- a/vote/http/http.go
+++ b/vote/http/http.go
@@ -314,12 +314,12 @@ func handleAllVotedIDs(voteCounter allVotedIDer, eventer func() (<-chan time.Tim
 			diff := make(map[int][]int)
 
 			if voterMemory == nil {
-				voterMemory = copyVoteIDs(newAllVotedIDs)
+				voterMemory = newAllVotedIDs
 				diff = newAllVotedIDs
 			} else {
 				for pollID, newUserIDs := range newAllVotedIDs {
 					if oldUserIDs, ok := voterMemory[pollID]; !ok {
-						voterMemory[pollID] = slices.Clone(newUserIDs)
+						voterMemory[pollID] = newUserIDs
 						diff[pollID] = newUserIDs
 					} else {
 						for _, newUserID := range newUserIDs {
@@ -360,14 +360,6 @@ func handleAllVotedIDs(voteCounter allVotedIDer, eventer func() (<-chan time.Tim
 			}
 		}
 	}
-}
-
-func copyVoteIDs(in map[int][]int) map[int][]int {
-	out := make(map[int][]int, len(in))
-	for k, v := range in {
-		out[k] = slices.Clone(v)
-	}
-	return out
 }
 
 func handleHealth() HandlerFunc {

--- a/vote/vote.go
+++ b/vote/vote.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sync"
 	"time"
 
@@ -483,7 +484,12 @@ func (v *Vote) Voted(ctx context.Context, pollIDs []int, requestUser int) (map[i
 func (v *Vote) AllVotedIDs(ctx context.Context) map[int][]int {
 	v.votedMu.Lock()
 	defer v.votedMu.Unlock()
-	return v.voted
+
+	out := make(map[int][]int, len(v.voted))
+	for k, v := range v.voted {
+		out[k] = slices.Clone(v)
+	}
+	return out
 }
 
 // loadVoted creates the value for v.voted by the backends.


### PR DESCRIPTION
This creates a copy of the voted user ids every time it is requested. This is once a second for each autoupdate instance.

Before this fix, it was only when a autoupdate-instance first connected.

But I think the copy has to be done inside the mutex.