### PR TITLE
Replacing 'as' with 'AS' in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG CONTEXT=prod
 
-FROM golang:1.24.5-alpine as base
+FROM golang:1.24.5-alpine AS base
 
 ## Setup
 ARG CONTEXT
@@ -23,7 +23,7 @@ HEALTHCHECK CMD ["/app/openslides-vote-service/openslides-vote-service", "health
 
 # Development Image
 
-FROM base as dev
+FROM base AS dev
 
 RUN ["go", "install", "github.com/githubnemo/CompileDaemon@latest"]
 
@@ -31,7 +31,7 @@ CMD CompileDaemon -log-prefix=false -build="go build" -command="./openslides-vot
 
 # Testing Image
 
-FROM base as tests
+FROM base AS tests
 
 # Install Dockertest & Docker
 RUN apk add --no-cache \
@@ -47,10 +47,10 @@ CMD ["sleep", "inf"]
 
 # Production Image
 
-FROM base as builder
+FROM base AS builder
 RUN go build
 
-FROM scratch as prod
+FROM scratch AS prod
 
 ## Setup
 ARG CONTEXT


### PR DESCRIPTION
Lower case 'as' causes linting warnings from docker compose