### PR TITLE
feat: pass database pool to auth for OIDC user lookup

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,13 +103,13 @@ func initService(lookup environment.Environmenter) (func(context.Context) error,
 	messageBus := messageBusRedis.New(lookup)
 
 	// Datastore Service.
-	database, err := vote.Flow(lookup, messageBus)
+	database, dbPool, err := vote.Flow(lookup, messageBus)
 	if err != nil {
 		return nil, fmt.Errorf("init database: %w", err)
 	}
 
 	// Auth Service.
-	authService, authBackground, err := auth.New(lookup, messageBus)
+	authService, authBackground, err := auth.New(lookup, messageBus, dbPool)
 	if err != nil {
 		return nil, fmt.Errorf("init auth system: %w", err)
 	}

--- a/vote/flow.go
+++ b/vote/flow.go
@@ -7,16 +7,18 @@ import (
 	"github.com/OpenSlides/openslides-go/datastore/cache"
 	"github.com/OpenSlides/openslides-go/datastore/flow"
 	"github.com/OpenSlides/openslides-go/environment"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Flow initializes a cached connection to postgres.
-func Flow(lookup environment.Environmenter, messageBus flow.Updater) (flow.Flow, error) {
+// Returns the flow, the postgres pool (for auth OIDC user lookup), and an error.
+func Flow(lookup environment.Environmenter, messageBus flow.Updater) (flow.Flow, *pgxpool.Pool, error) {
 	postgres, err := datastore.NewFlowPostgres(lookup)
 	if err != nil {
-		return nil, fmt.Errorf("init postgres: %w", err)
+		return nil, nil, fmt.Errorf("init postgres: %w", err)
 	}
 
 	cache := cache.New(postgres)
 
-	return cache, nil
+	return cache, postgres.Pool, nil
 }


### PR DESCRIPTION
## Summary

- Pass database pool to `auth.New()` to enable OIDC user resolution via PostgreSQL

## Context

Trivial change (2 files, 7 lines). Part of the Keycloak OIDC integration. Depends on [openslides-go#170](https://github.com/OpenSlides/openslides-go/pull/170).

## Test plan

- [ ] Service compiles and starts with updated `auth.New()` signature
- [ ] Existing vote functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)