### PR TITLE
write history

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenSlides/openslides-vote-service
 go 1.26.0
 
 require (
-	github.com/OpenSlides/openslides-go v0.0.0-20260520154826-117a72a06e70
+	github.com/OpenSlides/openslides-go v0.0.0-20260611111313-c32c5b93bec3
 	github.com/alecthomas/kong v1.14.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/shopspring/decimal v1.4.0
@@ -43,6 +43,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/OpenSlides/openslides-go v0.0.0-20260520154826-117a72a06e70 h1:0lVcfjcEEXwW4kjn8uH4oZsotF7UfmnzPUvigd+pxow=
-github.com/OpenSlides/openslides-go v0.0.0-20260520154826-117a72a06e70/go.mod h1:gBGblP71JLPI/45U+QqUfmEtvmNV7+LAfazGZR2n1qc=
+github.com/OpenSlides/openslides-go v0.0.0-20260611111313-c32c5b93bec3 h1:QP/eFS+dO5N6NCvGU/eVDa9wcjDsXv7NfdTaTOj0rd4=
+github.com/OpenSlides/openslides-go v0.0.0-20260611111313-c32c5b93bec3/go.mod h1:qkICl8CAXzm2txb2Y+rdWc9TEWt28gRoqsdXFrnVh/8=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/kong v1.14.0 h1:gFgEUZWu2ZmZ+UhyZ1bDhuutbKN1nTtJTwh19Wsn21s=
@@ -98,8 +98,8 @@ go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLh
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
 golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/vote/vote.go
+++ b/vote/vote.go
@@ -565,6 +565,12 @@ func (v *Vote) Delete(ctx context.Context, pollID int, requestUserID int) error 
 		return fmt.Errorf("write histroy: %w", err)
 	}
 
+	// Can be removed after https://github.com/OpenSlides/openslides-meta/issues/220
+	sql = `UPDATE history_entry_t set model_id=NULL WHERE model_id = $1;`
+	if _, err := tx.Exec(ctx, sql, fmt.Sprintf("poll/%d", pollID)); err != nil {
+		return fmt.Errorf("update old history entries: %w", err)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit transaction: %w", err)
 	}

--- a/vote/vote.go
+++ b/vote/vote.go
@@ -21,6 +21,7 @@ import (
 	"github.com/OpenSlides/openslides-go/datastore/dsmodels"
 	"github.com/OpenSlides/openslides-go/datastore/flow"
 	"github.com/OpenSlides/openslides-go/environment"
+	"github.com/OpenSlides/openslides-go/history"
 	"github.com/OpenSlides/openslides-go/perm"
 	"github.com/OpenSlides/openslides-vote-service/vote/method"
 	"github.com/jackc/pgx/v5"
@@ -169,6 +170,10 @@ func (v *Vote) Create(ctx context.Context, requestUserID int, r io.Reader) (int,
 		if _, err := tx.Exec(ctx, groupSQL, args...); err != nil {
 			return 0, fmt.Errorf("insert group-poll relations: %w", err)
 		}
+	}
+
+	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", newID), ci.MeetingID, "created"); err != nil {
+		return 0, fmt.Errorf("write histroy: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -390,6 +395,10 @@ func (v *Vote) Update(ctx context.Context, pollID int, requestUserID int, r io.R
 		}
 	}
 
+	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "updated"); err != nil {
+		return fmt.Errorf("write histroy: %w", err)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit transaction: %w", err)
 	}
@@ -552,6 +561,10 @@ func (v *Vote) Delete(ctx context.Context, pollID int, requestUserID int) error 
 		return fmt.Errorf("delete poll: %w", err)
 	}
 
+	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "deleted"); err != nil {
+		return fmt.Errorf("write histroy: %w", err)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit transaction: %w", err)
 	}
@@ -578,14 +591,29 @@ func (v *Vote) Start(ctx context.Context, pollID int, requestUserID int) error {
 		return fmt.Errorf("preloading poll: %w", err)
 	}
 
+	tx, err := v.querier.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Set published, if live voting is enabled.
 	sql := `UPDATE poll SET state = 'started', published = $2 WHERE id = $1 AND state != 'finished';`
-	commandTag, err := v.querier.Exec(ctx, sql, pollID, poll.LiveVotingEnabled)
+	commandTag, err := tx.Exec(ctx, sql, pollID, poll.LiveVotingEnabled)
 	if err != nil {
 		return fmt.Errorf("set poll %d to started: %w", pollID, err)
 	}
 
 	if commandTag.RowsAffected() != 1 {
 		return fmt.Errorf("poll %d not found or not in 'created' state", pollID)
+	}
+
+	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "started"); err != nil {
+		return fmt.Errorf("write histroy: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit transaction: %w", err)
 	}
 
 	return nil
@@ -617,7 +645,11 @@ func (v *Vote) Finalize(ctx context.Context, pollID int, requestUserID int, publ
 	}
 	defer tx.Rollback(ctx)
 
+	historyMessages := make([]string, 0, 4)
+	historyMessages = append(historyMessages, "finalized")
+
 	if poll.State == `started` {
+		historyMessages = append(historyMessages, "stopped")
 		ds := dsmodels.New(v.flow)
 
 		ballots, err := ds.PollBallot(poll.BallotIDs...).Get(ctx)
@@ -712,7 +744,12 @@ func (v *Vote) Finalize(ctx context.Context, pollID int, requestUserID int, publ
 		return fmt.Errorf("set poll %d to finished and publish to %v: %w", pollID, publish, err)
 	}
 
+	if publish && !poll.Published {
+		historyMessages = append(historyMessages, "published")
+	}
+
 	if anonymize {
+		historyMessages = append(historyMessages, "anonymized")
 		if poll.Visibility == "named" {
 			return MessageError(ErrNotAllowed, "A named-poll can not be anonymized.")
 		}
@@ -732,6 +769,10 @@ func (v *Vote) Finalize(ctx context.Context, pollID int, requestUserID int, publ
 		if _, err := tx.Exec(ctx, sqlPoll, pollID); err != nil {
 			return fmt.Errorf("set anonymize on poll: %w", err)
 		}
+	}
+
+	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, historyMessages...); err != nil {
+		return fmt.Errorf("write histroy: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -786,6 +827,10 @@ func (v *Vote) Reset(ctx context.Context, pollID int, requestUserID int) error {
 	deleteVotedQuery := `DELETE FROM nm_meeting_user_poll_voted_ids_poll_t WHERE poll_id = $1`
 	if _, err := tx.Exec(ctx, deleteVotedQuery, pollID); err != nil {
 		return fmt.Errorf("delete poll votes: %w", err)
+	}
+
+	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "resetted"); err != nil {
+		return fmt.Errorf("write histroy: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/vote/vote.go
+++ b/vote/vote.go
@@ -835,7 +835,7 @@ func (v *Vote) Reset(ctx context.Context, pollID int, requestUserID int) error {
 		return fmt.Errorf("delete poll votes: %w", err)
 	}
 
-	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "resetted"); err != nil {
+	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "reset"); err != nil {
 		return fmt.Errorf("write history: %w", err)
 	}
 

--- a/vote/vote.go
+++ b/vote/vote.go
@@ -173,7 +173,7 @@ func (v *Vote) Create(ctx context.Context, requestUserID int, r io.Reader) (int,
 	}
 
 	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", newID), ci.MeetingID, "created"); err != nil {
-		return 0, fmt.Errorf("write histroy: %w", err)
+		return 0, fmt.Errorf("write history: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -396,7 +396,7 @@ func (v *Vote) Update(ctx context.Context, pollID int, requestUserID int, r io.R
 	}
 
 	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "updated"); err != nil {
-		return fmt.Errorf("write histroy: %w", err)
+		return fmt.Errorf("write history: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -562,7 +562,7 @@ func (v *Vote) Delete(ctx context.Context, pollID int, requestUserID int) error 
 	}
 
 	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "deleted"); err != nil {
-		return fmt.Errorf("write histroy: %w", err)
+		return fmt.Errorf("write history: %w", err)
 	}
 
 	// Can be removed after https://github.com/OpenSlides/openslides-meta/issues/220
@@ -615,7 +615,7 @@ func (v *Vote) Start(ctx context.Context, pollID int, requestUserID int) error {
 	}
 
 	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "started"); err != nil {
-		return fmt.Errorf("write histroy: %w", err)
+		return fmt.Errorf("write history: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -778,7 +778,7 @@ func (v *Vote) Finalize(ctx context.Context, pollID int, requestUserID int, publ
 	}
 
 	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, historyMessages...); err != nil {
-		return fmt.Errorf("write histroy: %w", err)
+		return fmt.Errorf("write history: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -836,7 +836,7 @@ func (v *Vote) Reset(ctx context.Context, pollID int, requestUserID int) error {
 	}
 
 	if err := history.OneEntry(ctx, tx, requestUserID, fmt.Sprintf("poll/%d", pollID), poll.MeetingID, "resetted"); err != nil {
-		return fmt.Errorf("write histroy: %w", err)
+		return fmt.Errorf("write history: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {


### PR DESCRIPTION
@vkrasnovyd When I try to delete a poll with with history entries, I get the error message

`ERROR: update or delete on table "poll_t" violates foreign key constraint "fk_history_entry_t_model_id_poll_id_poll_t_id" on table "history_entry_t" (SQLSTATE 23503)`

Do I have to manually cleat the model_id values? Would it be possible for the sql schema to do this automatically? 