### PR TITLE
[vote] Update docs

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -59,6 +59,11 @@ unpublished results of the polls.
 
 ## Migrating the polls
 
+NOTE: there parts are still in dicsussion and may change:
+
+* Migration of the assignment polls
+* Possible onehundred_percent_base values based on the old logic
+
 ### General rules
 
 The following information is relevant for all the poll types.
@@ -501,11 +506,11 @@ It's a dictionary where each key-value pair represents an old `vote`:
 * Fields that were renamed:
   * meeting/motion_poll_projection_name_order_first -> poll_projection_name_order_first
   * meeting/motion_poll_projection_max_columns -> poll_projection_max_columns
+  * meeting/assignment_poll_enable_max_votes_per_option -> poll_enable_max_votes_per_option
 * Fields that need to be moved to meeting_poll_default:
   * meeting/*_poll_group_ids -> meeting_poll_default/group_ids
   * meeting/*_poll_ballot_paper_selection -> meeting_poll_default/ballot_paper_selection
   * meeting/*_poll_ballot_paper_number -> meeting_poll_default/ballot_paper_number
-  * meeting/*_poll_sort_result_by_votes -> meeting_poll_default/sort_result_by_votes
   * meeting/*_poll_sort_result_by_votes -> meeting_poll_default/sort_result_by_votes
 * Fields should be renamed and values should be changed similarly to poll/type:
   * meeting/*_poll_default_type -> meeting_poll_default/visibility

--- a/Migration.md
+++ b/Migration.md
@@ -63,24 +63,38 @@ unpublished results of the polls.
 
 The following information is relevant for all the poll types.
 
-#### poll and poll_config_X
+#### poll, poll_config_X and poll_option
 
-For each old poll 2 models have to be created: a new `poll` and a related
-`poll_config_X`. How the data should be migrated depends on whether it is a
-motion, assignment or a topic poll. When it comes to assignement polls, there
-are 3 possibilities based on content_object_id and whether the global yes or no
-option is used.
+Regardless of the type, for each old poll 2 models have to be created: a new
+`poll` and a related `poll_config_X`. Additionally for some poll types
+`poll_option` models should be generated.
+
+How the data should be migrated depends on whether it is a motion, assignment
+or a topic poll. When it comes to assignement polls, there are 3 possibilities
+based on content_object_id and whether the global yes or no option is used.
 
 #### poll_ballot objects and poll/result
 
-If poll.state is "created" or "started", then poll/result is empty.
+If old_poll.type is "analog" (corresponds to the new visibility "manually"),
+no ballots should be created for the poll. Othervise `poll_ballot` models
+should be generated from the old votes.
 
-If old_poll.state if "analog" (corresponds to the new state "manually"), no
-ballots should be created for the poll. The result for the finished polls in
-this case should be carried over from the old poll.
+If poll.state is "created" or "started", then poll/result is empty. Otherwise
+it should be generated from the old votes and options.
 
-For the other finished poll the ballots have to be generated from the votes
-and the result has to be calculated and saved in the field `poll/result`.
+Additionally to the calculated part, poll/result can include 2 extra values
+carried over from the old poll:
+
+* total_ballots (old_poll.votescast): it's the total number of votes that
+  includes both valid and invalid votes. Should be always included into the
+  result.
+* invalid (old_poll.votesinvalid): should be included into the result only if
+  new_poll.visibility == "manually"
+
+"total_ballots" and "invalid" should be saved as integers.
+
+Old polls used to have a separate field for the valid votes: `votesvalid`. It
+should be omitted in the migration.
 
 ### motion
 
@@ -114,16 +128,16 @@ and the result has to be calculated and saved in the field `poll/result`.
       - pseudoanonymous -> secret
       - cryptographic -> @panic(immpossible)
   state: if old.state == "published" then "finished" else old.state,
-  result: old.result if old.type == "analog" else see below,
+  result: see below,
   published: old.state == "published",
   anonymized: old.is_pseudoanonymized,
-  allow_invalid: old.type == "analog",
+  allow_invalid: false,
   allow_vote_split: false,
-  live_voting_enabled: old.live_voting_enabled if old.type != "analog",
+  live_voting_enabled: old.live_voting_enabled,
   sequential_number: old.sequential_number,
   content_object_id: old.content_object_id,
   voted_ids: old.voted_ids -> replace each user_id with meeting_user_id in poll.meeting_id,
-  entitled_group_ids: old.entitled_group_ids if old.type != "analog",
+  entitled_group_ids: old.entitled_group_ids,
   meeting_id: old.meeting_id,
 }
 ```
@@ -135,10 +149,10 @@ In the old system, there is one option per poll. There is also a global option,
 but this can be ignored. The new `poll/result` essentially corresponds to this
 single option. If there is more than one option, then @panic.
 
-The value "total_ballots" is calculated additionally. It should be stored as an
-integer. The other values are strings as they are decimal.
+Values for "invalid" and "total_ballots" should be stored as integers. The
+other values are strings as they are decimal.
 
-Example: `{"yes":"32","no":"20","abstain":"10","total_ballots":62}`
+Example: `{"yes":"32","no":"20","abstain":"10","invalid":2,"total_ballots":64}`
 
 Calculated from `old_poll.option_ids[0].vote_ids`:
 
@@ -147,6 +161,7 @@ Calculated from `old_poll.option_ids[0].vote_ids`:
   yes: option.yes -> string,  (skip if 0)
   no: option.no -> string,  (skip if 0)
   abstain: option.abstain -> string,  (skip if 0)
+  invalid: old_poll.votesinvalid if new_poll.visibility == "manually" -> number,  (skip if 0)
   total_ballots: count(option.vote_ids) -> number
 }
 ```
@@ -213,16 +228,7 @@ collections are being migrated differently.
   allow_nota: old_poll.global_option_id exists,
   strike_out: old_poll.pollmethod == N,
   display_chart: pie,
-  onehundred_percent_base: old_poll.onehundred_percent_base. Map (old_poll -> new):
-      - YNA -> valid
-      - Y -> no_general
-      - N -> no_general
-      - valid: (remains unchanged).
-      - cast: (remains unchanged).
-      - entitled: (remains unchanged).
-      - entitled_present: (remains unchanged).
-      - disabled: (remains unchanged).
-      - YN -> @panic(not allowed for this config type)
+  onehundred_percent_base: no_general
 }
 ```
 
@@ -248,7 +254,7 @@ poll_option.text. The value is being calculated from the old votes.
 `global_yes` and `global_no` in polls with `poll_config_selection` are being
 calculated separately into the value "nota".
 
-Example: `{"Option 1":"40","Option 2":"23","nota":"6","abstain":"7","total_ballots":76}`
+Example: `{"Option 1":"40","Option 2":"23","nota":"6","abstain":"7","invalid":3,"total_ballots":79}`
 
 Calculation:
 ```
@@ -258,7 +264,8 @@ Calculation:
 
   abstain: sum(all_options.abstain) -> string,  (skip if 0)
   nota: old_poll.global_option_id -> (option.yes + option.no) -> string,  (skip if 0)
-  total_ballots: count(all_options.vote_ids) -> number
+  invalid: old_poll.votesinvalid if new_poll.visibility == "manually" -> number,  (skip if 0)
+  total_ballots: old_poll.votescast -> number
 }
 ```
 
@@ -327,7 +334,7 @@ but it always has `allow_nota: true` and should not have `display_chart`:
 Calculated similarly to the topic polls, but ids of the poll_options created
 above are used as the keys instead of the poll_option/text.
 
-Example: `{"1":"40","2":"23","nota":"6","abstain":"7","total_ballots":76}`
+Example: `{"1":"40","2":"23","nota":"6","abstain":"7","invalid":3,"total_ballots":79}`
 
 Calculation:
 ```
@@ -337,7 +344,8 @@ Calculation:
 
   abstain: sum(all_options.abstain) -> string,  (skip if 0)
   nota: old_poll.global_option_id -> (option.yes + option.no) -> string,  (skip if 0)
-  total_ballots: count(all_options.vote_ids) -> number
+  invalid: old_poll.votesinvalid if new_poll.visibility == "manually" -> number,  (skip if 0)
+  total_ballots: old_poll.votescast -> number
 }
 ```
 
@@ -375,16 +383,16 @@ Calculation:
       - pseudoanonymous -> secret
       - cryptographic -> @panic(immpossible)
   state: if old.state == "published" then "finished" else old.state,
-  result: old.result if old.type == "analog" else see below,
+  result: see below,
   published: old.state == "published",
   anonymized: old.is_pseudoanonymized,
-  allow_invalid: old.type == "analog",
+  allow_invalid: false,
   allow_vote_split: false,
-  live_voting_enabled: old.live_voting_enabled if old.type != "analog",
+  live_voting_enabled: old.live_voting_enabled,
   sequential_number: old.sequential_number,
   content_object_id: old.content_object_id,
   voted_ids: for each user in old.voted_ids -> meeting_user_id in old.meeting_id,
-  entitled_group_ids: old.entitled_group_ids if old.type != "analog",
+  entitled_group_ids: old.entitled_group_ids,
   meeting_id: old.meeting_id
 }
 ```
@@ -411,7 +419,7 @@ Poll/result is a dict. There is one entry for each old option. The key is
 the poll_option-id created above. The values "yes", "no" and "abstain" are
 adopted as objects.
 
-Example: `{"1":{"yes":"5","no":"1"},"2":{"yes":"1","abstain":"6"},"total_ballots":7}`
+Example: `{"1":{"yes":"5","no":"1"},"2":{"yes":"1","abstain":"6"},"invalid":1,"total_ballots":7}`
 
 Calculation:
 ```
@@ -423,7 +431,8 @@ Calculation:
       abstain: option.abstain -> string   (skip if 0)
     },
 
-  total_ballots: count(all_options.vote_ids) -> number
+  invalid: old_poll.votesinvalid if new_poll.visibility == "manually" -> number,  (skip if 0)
+  total_ballots: old_poll.votescast -> number
 }
 ```
 
@@ -474,12 +483,10 @@ It's a dictionary where each key-value pair represents an old `vote`:
 
 ## Changes in old fields by collection
 
-### Group (permissions)
+### Group
 
-* group/permissions: poll.can_manage was replaced with 3 separate permissions:
-  * motion.can_manage_polls (existing)
-  * assignment.can_manage_polls (existing)
-  * agenda_item.can_manage_polls (new)
+* group/permissions: poll.can_manage -> agenda_item.can_manage_polls (migration
+  is needed)
 
 To be discussed: should all the users who previously had `poll.can_manage` get
 all the 3 collection-specific permissions.
@@ -521,8 +528,6 @@ all the 3 collection-specific permissions.
   * poll/live_votes
   * poll/entitled_users_at_stop
   * poll/votesvalid
-  * poll/votesinvalid
-  * poll/votescast
 * poll/is_pseudoanonymized -> poll/anonymized.
 * poll/type -> poll/visibility and the values have changed:
   * analog -> manually
@@ -556,6 +561,8 @@ all the 3 collection-specific permissions.
   * poll/global_no
   * poll/global_abstain
   * poll/global_option_id
+  * poll/votescast
+  * poll/votesinvalid
 
 ### Poll_candidate_list
 

--- a/Migration.md
+++ b/Migration.md
@@ -1,54 +1,61 @@
-# Migration zum neuen Vote-Service
+# Migration to the new Vote-Service
 
-Das alte System und das neue unterscheiden sich wesentlich. Eine eins zu eins
-übersetzung der alten und neuen Felder ist nicht möglich.
+The old system and the new one differ significantly. It is not possible to map
+the old and new fields on a one-to-one basis.
 
+## Previous system
 
-## Bisheriges System
+In the current system, each poll has several options. These are linked via
+`poll/option_ids` and `poll/global_option_id`. A global option was also created
+for motions, even though it should never be used there.
 
-Im bisherigen System hat jede Poll mehrere optionen. Diese werden über
-`poll/option_ids` und `poll/global_option_id` verlinkt. Auch für motions wird
-eine global-option angelegt, obwohl diese dort nie verwendet werden sollte.
+Each option has the values `yes`, `no` and `abstain`. When voting, each user
+selects one of these three options for each poll. There are therefore several
+`vote` objects per user. These are always stored as yes-no-abstain, even if it
+is actually a selection. The `option` objects contain the result. They store
+the sum of all vote objects relating to them in the `yes`-`no`-`abstain`
+fields. The global options are counted separately. Hence "General approval",
+"General rejection" or "General abstain".
 
-Jede option hat die Werte `yes`, `no` und `abstain`. Bei der Abstimmung gibt
-jeder Nutzer für jede Option eine dieser drei Möglichkeiten an. Es gibt daher
-pro User mehrere `vote` objekte. Diese werden immer als Ja-Nein-Enthaltung
-gespeichert, auch wenn es eigentlich eine Auswahl ist. Die `option`-Objekte
-enthalten das Result. Sie speichern in den `yes`-`no`-`abstain`-Feldern die
-Summe aller auf sie bezogenen vote objekte. Die globale Obtion werden separat
-gezählt. Daher als "Generelle Ablehnung", "Generelle Enthaltung" oder "Generelle
-Zustimmung".
+The `vote` objects serve solely to display who voted and how. The `user_token`
+field helps to group together different votes from a single user if the user ID
+has been removed. In non-anonymised polls, `vote/user_id` is the user for whom
+the vote is to be counted, and `vote/delegated_user_id` is the user who cast
+the vote. If multiple votes are permitted per user, these votes are aggregated
+in the vote objects via the vote-weight feature.
 
-Die vote objekte dienen lediglich der Anzeige, wer wie abgestimmt hat. Das Feld
-`user_token` hilft dabei, verschiedene votes eines Nutzers zu bündeln, wenn die
-user-id entfernt wurde. Bei nicht anonymisierten polls is `vote/user_id` der
-Nutzer, für den die Stimme gezählt werden soll und `vote/ delegated_user_id`,
-der die Stimme abgegeben hat. Werden pro Nutzer mehrere Stimmen erlaubt, dann
-werden diese Stimmen in den vote-objekten über das vote-weight-feature
-gebündelt.
+The data actually sent by the user is not stored, but is interpreted and
+distributed across the vote objects.
 
-Die vom Nutzer eigentlich gesendeten Daten werden nicht gespeichert, sondern
-interpretiert in die vote-objekte aufgeteilt.
+## New system
 
-Fragen: Sind folgende Aussagen korrekt:
-* Bei motion gibt es zwar immer eine global-option, diese wurde aber nie genutzt.
+The old `option` collection and the new `poll_option` are two different things
+that just happen to have similar names. In the new system, options no longer
+contain the result. The new collection `poll_option` is only used in the
+elections for storing the possible options.
 
+Such system makes old collections `poll_candidate_list` and `poll_candidate`
+redundant. Relations between the poll and the candidates are now defined
+directly in the `poll_option` via `meeting_user_id` field.
 
+The votes (collection is now called `poll_ballot`) contain exactly the data
+that a user has submitted. There is therefore only one ballot object per poll
+and user.
 
-## Neues System
+## Permissions
 
-Im neuen System gibt es keine optionen. Stattdessen wird das Ergebnis direkt im
-Feld `poll/result` gebündelt. Die Votes (jetzt ballot genannt) enthalten genau
-die Daten, die ein Nutzer gesendet hat. Es gibt daher pro Poll und User nur ein
-ballot-objekt. options gibt es nicht mehr als Collection. Jedoch werden bei
-Wahlen die möglichen optionen in `poll_option` gespeichert. Die alte
-`options` collection und die neue `poll_option` sind zwei verschiedene Dinge
-die nur zufällig ähnlich heißen.
+In the old system along with the separate `can_manage_polls` for assinments and
+motions there was also a general setting `poll.can manage`. In the new system
+this general permission was replaced with 3 distinct permissions depending on
+the value in the `content_object_id` field:
 
-Eigentlich sollte das Feld `poll/result` redundant sein. Daher, es lässt sich zu
-jeder Zeit aus den votes neu berechnen. Dies gilt nicht für manuelle polls und
-es wäre in Ordnung, wenn es auch nicht für migrierte polls gilt.
+* motions: `motion.can_manage_polls`
+* assignments: `assignment.can_manage_polls`
+* topic: `agenda_item.can_manage_polls`  (new)
 
+New system also introduces a new child permission `can_see_polls` for each of
+these content object collections. This permissions allows to see the
+unpublished results of the polls.
 
 ## Migrating the polls
 

--- a/Migration.md
+++ b/Migration.md
@@ -50,11 +50,30 @@ jeder Zeit aus den votes neu berechnen. Dies gilt nicht für manuelle polls und
 es wäre in Ordnung, wenn es auch nicht für migrierte polls gilt.
 
 
-## Übertragung
+## Migrating the polls
 
-Pro altem poll (`old`) wird ein neues Poll erstellt. Dieses hängt davon ab, ob
-es eine motion, assignment oder topic poll ist.
+### General rules
 
+The following information is relevant for all the poll types.
+
+#### poll and poll_config_X
+
+For each old poll 2 models have to be created: a new `poll` and a related
+`poll_config_X`. How the data should be migrated depends on whether it is a
+motion, assignment or a topic poll. When it comes to assignement polls, there
+are 3 possibilities based on content_object_id and whether the global yes or no
+option is used.
+
+#### poll_ballot objects and poll/result
+
+If poll.state is "created" or "started", then poll/result is empty.
+
+If old_poll.state if "analog" (corresponds to the new state "manually"), no
+ballots should be created for the poll. The result for the finished polls in
+this case should be carried over from the old poll.
+
+For the other finished poll the ballots have to be generated from the votes
+and the result has to be calculated and saved in the field `poll/result`.
 
 ### motion
 
@@ -62,11 +81,18 @@ es eine motion, assignment oder topic poll ist.
 
 ```
 {
-  id: kann automatisch erstellt werden,
-  poll_id: ID zum neuen poll objekt.
-  allow_abstain: if old.method == "YNA" then "" else false,
-  onehundred_percent_base: old.onehundred_percent_base  (Die werte sind anders. Bitte mit Bastian besprechen, wie diese am besten gemappt werden)
-  
+  poll_id: new_poll.id,
+  allow_abstain: if old.method == "YNA" then "true" else "false",
+  onehundred_percent_base: old_poll.onehundred_percent_base. Map (old_poll -> new):
+      - YN -> yes_no
+      - YNA -> valid
+      - valid: (remains unchanged).
+      - cast: (remains unchanged).
+      - entitled: (remains unchanged).
+      - entitled_present: (remains unchanged).
+      - disabled: (remains unchanged).
+      - Y -> @panic(not allowed for this config type)
+      - N -> @panic(not allowed for this config type)
 }
 ```
 
@@ -74,20 +100,23 @@ es eine motion, assignment oder topic poll ist.
 
 ```
 {
-  id: old.id,
   title: old.title,
-  visibility: old{"analog": "manually", "named": "open", "pseudoanonymous": "secret", "cryptographic": @panic(immpossible)},
+  visibility: old.type. Map (old -> new):
+      - analog -> manually
+      - named -> open
+      - pseudoanonymous -> secret
+      - cryptographic -> @panic(immpossible)
   state: if old.state == "published" then "finished" else old.state,
-  result: see below,
+  result: old.result if old.type == "analog" else see below,
   published: old.state == "published",
   anonymized: old.is_pseudoanonymized,
-  allow_invalid: false,
+  allow_invalid: old.type == "analog",
   allow_vote_split: false,
-  live_voting_enabled: old.live_voting_enabled,
+  live_voting_enabled: old.live_voting_enabled if old.type != "analog",
   sequential_number: old.sequential_number,
   content_object_id: old.content_object_id,
-  voted_ids: old.voted_ids,
-  entitled_group_ids: old.entitled_group_ids,
+  voted_ids: old.voted_ids -> replace each user_id with meeting_user_id in poll.meeting_id,
+  entitled_group_ids: old.entitled_group_ids if old.type != "analog",
   meeting_id: old.meeting_id,
 }
 ```
@@ -95,172 +124,346 @@ es eine motion, assignment oder topic poll ist.
 
 #### poll/result
 
-Im alten System gibt es pro poll eine Option. Es gibt zusätzlich eine
-global-option, die jedoch ignoriert werden kann. Das neue `poll/result`
-entspricht im wesentlichen dieser einen option. Sollte es mehr als eine option
-geben, dann @panic.
+In the old system, there is one option per poll. There is also a global option,
+but this can be ignored. The new `poll/result` essentially corresponds to this
+single option. If there is more than one option, then @panic.
 
-Wenn poll.state "created" oder "started" ist, dann ist poll/result leer. Ansonsten:
+The value "total_ballots" is calculated additionally. It should be stored as an
+integer. The other values are strings as they are decimal.
 
-`poll/result`: `{"yes": option.yes, "no": option.no, "abstain": option.abstain}`
+Example: `{"yes":"32","no":"20","abstain":"10","total_ballots":62}`
 
-Bei manually polls werden invalide Stimmen unterstützt. Diese standen bisher in
-poll.votesinvalid. In Zukunft können sie als weiteres attribute in `poll/result`
-geschrieben werden. Allerdings nicht als decimal, sondern als int. `{...,
-"invalid": 42}`
-
-
-#### poll_ballot
-
-Wenn poll.state "created" oder "started" ist, dann gibt es keine ballots.
-
-Wenn poll.visibility == "manually", dann wird kein ballot-objekt erstellt.
-
-Ansonsten:
-
-Im alten system gibt es pro user nur ein vote. Die Votes können über
-old_poll.option_ids[0].vote_ids gefunden werden.
+Calculated from `old_poll.option_ids[0].vote_ids`:
 
 ```
 {
-  id: kann automatisch erstellt werden ich würde nicht die alten ids verwenden,
+  yes: option.yes -> string,  (skip if 0)
+  no: option.no -> string,  (skip if 0)
+  abstain: option.abstain -> string,  (skip if 0)
+  total_ballots: count(option.vote_ids) -> number
+}
+```
+
+#### poll_ballot
+
+In the old system only one vote should exist per user. The votes can be found
+via `old_poll.option_ids[0].vote_ids`. For each old vote a new
+`poll_ballot` object sould be created:
+
+```
+{
+  poll_id: new_poll.id,
   weight: old.weight,
   split: false,
-  value: old{"Y": "yes", "N": "no", "A": "abstain"} ansonsten @panic,
-  poll_id: old.poll_id,
-  acting_meeting_user_id: old.delegated_user_id -> jedoch seine meeting_user_id im poll.meeting,
-  represented_meeting_user_id: old.user_id -> jedoch seine meeting_user_id im poll.meeting,
+  value: Map (old -> new):
+      - Y -> yes
+      - N -> no
+      - A -> abstain
+      - else @panic(impossible value)
+  acting_meeting_user_id: meeting_user_id from old.delegated_user_id and poll.meeting,
+  represented_meeting_user_id: meeting_user_id from old.user_id and poll.meeting
 }
 ```
 
 
-### assignment
+### assignment with poll_candidate_list
 
-Wenn im alten system "Ja/Nein/Enthaltung pro Liste" ausgewählt wurde (Ich
-glaube, dann gibt es nur eine option mit content_object_id auf
-poll_candidate_list), dann behandle es wie bei motion. Daher mit "method":
-"approval". Daher alles hier ignorieren und nur wie bei motion bearbeiten.
-Jedoch müssen die einzelnen Einträge in der Liste als `poll_option` gespeichert
-werden.
+If in the old system the collection of `old_poll.content_object_id` is
+`poll_candidate_list`, the following collections should be created the same way
+as for the [Motion poll](#motion):
 
+* poll_config_approval
+* poll (including calculation of poll/result)
+* poll_ballot
+
+#### poll_option
+
+Additionally, each `poll_candidate` ("old") in
+`old_poll.option_ids[0].content_object_id.poll_candidate_ids` should be saved as
+a `poll_option`:
+
+```
+{
+  poll_id: new_poll.id,
+  weight: old.weight,
+  text: NULL,
+  meeting_user_id: meeting_user_id from old.user_id and old.meeting_id
+}
+```
+
+### topic
+
+`poll` is being created the same way as for [Motion poll](#motion). The other
+collections are being migrated differently.
+
+#### poll_config_selection
+
+```
+{
+  poll_id: new_poll.id,
+  max_options_amount: old_poll.max_votes_amount,
+  min_options_amount: old_poll.min_votes_amount,
+  allow_nota: old_poll.global_option_id exists,
+  strike_out: old_poll.pollmethod == N,
+  display_chart: pie,
+  onehundred_percent_base: old_poll.onehundred_percent_base. Map (old_poll -> new):
+      - YNA -> valid
+      - Y -> no_general
+      - N -> no_general
+      - valid: (remains unchanged).
+      - cast: (remains unchanged).
+      - entitled: (remains unchanged).
+      - entitled_present: (remains unchanged).
+      - disabled: (remains unchanged).
+      - YN -> @panic(not allowed for this config type)
+}
+```
+
+#### poll_option
+
+A new `poll_option` should be created for each old `option` ("old"). They can
+be found via `old_poll.option_ids`.
+
+```
+{
+  poll_id: new_poll.id,
+  weight: old.weight,
+  text: old.text,
+  meeting_user_id: None
+}
+```
+
+#### poll/result
+
+For each old option there is one entry in the result dict. The key is the
+poll_option.text. The value is being calculated from the old votes.
+
+`global_yes` and `global_no` in polls with `poll_config_selection` are being
+calculated separately into the value "nota".
+
+Example: `{"Option 1":"40","Option 2":"23","nota":"6","abstain":"7","total_ballots":76}`
+
+Calculation:
+```
+{
+  for each option (if not option.used_as_global_option_in_poll_id == old_poll.id):
+    poll_option.text: option.yes -> string,  (skip if value is 0)
+
+  abstain: sum(all_options.abstain) -> string,  (skip if 0)
+  nota: old_poll.global_option_id -> (option.yes + option.no) -> string,  (skip if 0)
+  total_ballots: count(all_options.vote_ids) -> number
+}
+```
+
+#### poll_ballot
+
+```
+{
+  poll_id: new_poll.id,
+  weight: old.weight,
+  split: false,
+  value: old.value -> Replace old options ids with corresponding new poll_options ids,
+  acting_meeting_user_id: meeting_user_id from old.delegated_user_id and poll.meeting,
+  represented_meeting_user_id: meeting_user_id from old.user_id and poll.meeting
+}
+```
+
+### assignment with global_yes or global_no
+
+Assignment polls with `global_yes` or `global_no` in the new voting system will
+function almost like the topic polls: with `poll_config_selection` but with
+`meeting_user_id`s instead of the `text` in `poll_option`.
+
+Migrate poll this way if:
+
+* Collection of the old poll's content_object_id is `assignment`
+* Old poll has `global_option_id`
+* `global_yes` and/or `global_no` for the poll is true
+
+The following collections should be created the same way
+as for the [Topic poll](#topic):
+
+* poll
+* poll_option
+* poll_ballot
+
+Other collection have minor differences.
+
+#### poll_config_selection
+
+`poll_config_selection` for the assignment poll is similar to the topic poll
+but it always has `allow_nota: true` and should not have `display_chart`:
+
+```
+{
+  poll_id: new_poll.id,
+  max_options_amount: old_poll.max_votes_amount,
+  min_options_amount: old_poll.min_votes_amount,
+  allow_nota: true,
+  strike_out: old_poll.pollmethod == N,
+  display_chart: null,
+  onehundred_percent_base: old_poll.onehundred_percent_base. Map (old_poll -> new):
+      - YNA -> valid
+      - Y -> no_general
+      - N -> no_general
+      - valid: (remains unchanged).
+      - cast: (remains unchanged).
+      - entitled: (remains unchanged).
+      - entitled_present: (remains unchanged).
+      - disabled: (remains unchanged).
+      - YN -> @panic(not allowed for this config type)
+}
+```
+
+#### poll/result
+
+Calculated similarly to the topic polls, but ids of the poll_options created
+above are used as the keys instead of the poll_option/text.
+
+Example: `{"1":"40","2":"23","nota":"6","abstain":"7","total_ballots":76}`
+
+Calculation:
+```
+{
+  for each option (if not option.used_as_global_option_in_poll_id == old_poll.id):
+    poll_option.id: option.yes -> string,  (skip if value is 0)
+
+  abstain: sum(all_options.abstain) -> string,  (skip if 0)
+  nota: old_poll.global_option_id -> (option.yes + option.no) -> string,  (skip if 0)
+  total_ballots: count(all_options.vote_ids) -> number
+}
+```
+
+### assignment: other cases
 
 #### poll_config_rating_approval
 
 ```
 {
-  id: kann automatisch erstellt werden,
-  poll_id: old.id,
+  poll_id: new_poll.id,
   max_options_amount: old.max_votes_amount,
   min_options_amount: old.min_votes_amount,
-  allow_abstain: if old.method == "YNA" then "" else false,
-  onehundred_percent_base: old.onehundred_percent_base (siehe Werte bei Motion)
+  allow_abstain: if old.method == "YNA" then "true" else "false",
+  onehundred_percent_base: old.onehundred_percent_base. Map (old -> new):
+      - YN -> yes_no
+      - YNA -> valid
+      - valid: (remains unchanged).
+      - cast: (remains unchanged).
+      - entitled: (remains unchanged).
+      - entitled_present: (remains unchanged).
+      - disabled: (remains unchanged).
+      - Y -> @panic(not allowed for this config type)
+      - N -> @panic(not allowed for this config type)
 }
 ```
 
-
-#### poll_option
-
-Relevant sind die alten options (old_option) der poll. Für jede option sollte der Werte
-option.content_object_id ein user-collection sein. Ansonsten @panic. Von diesem
-Feld wird die user_id und zu dieser die meeting_user_id im entsprechenden meeting gesucht.
+#### poll
 
 ```
 {
-  id:
-  poll_id: Neue ID der poll,
-  weight: old_option.weight,
-  text: NULL,
-  meeting_user_id: old_option.content_object_id -> Davon user_id, von dieser die meeting_user_id,
-}
-```
-
-
-#### Poll
-
-```
-{
-  id: old.id,
   title: old.title,
-  visibility: old{"analog": "manually", "named": "open", "pseudoanonymous": "secret", "cryptographic": @panic(immpossible)},
+  visibility: old.type. Map (old -> new):
+      - analog -> manually
+      - named -> open
+      - pseudoanonymous -> secret
+      - cryptographic -> @panic(immpossible)
   state: if old.state == "published" then "finished" else old.state,
-  result: see below,
+  result: old.result if old.type == "analog" else see below,
   published: old.state == "published",
   anonymized: old.is_pseudoanonymized,
-  allow_invalid: false,
+  allow_invalid: old.type == "analog",
   allow_vote_split: false,
-  live_voting_enabled: old.live_voting_enabled,
+  live_voting_enabled: old.live_voting_enabled if old.type != "analog",
   sequential_number: old.sequential_number,
   content_object_id: old.content_object_id,
-  voted_ids: old.voted_ids,
-  entitled_group_ids: old.entitled_group_ids,
+  voted_ids: for each user in old.voted_ids -> meeting_user_id in old.meeting_id,
+  entitled_group_ids: old.entitled_group_ids if old.type != "analog",
   meeting_id: old.meeting_id
 }
 ```
 
+#### poll_option
 
-#### poll/result
-
-Poll/result ist ein dict. Pro alter option gibt es einen Eintrag. Der Key ist
-jeweils die oben angelegte poll_option-id. Die Werte "yes", "no" und "abstain"
-werden als object übernommen. Zusätzlich wird bei manuellen polls als weiterer
-Wert "invalid" aus der alten poll übernommen. Invalid ist ein int, die anderen
-Werte sind ein string (da decimal).
-
-`{"1":{"yes":"5","no":"1"},"2":{"yes":"1","abstain":"6"},"invalid":1}`
-
-Zusätzlich müssen die globalen Optionen in das Ergebnis mit einberechnet werden.
-Daher die "yes"-"no"-"abstain" Werte der globalen Abstimmung wird bei jeder
-Option addiert.
-
-
-#### poll_ballot
-
-Wenn poll.state "created" oder "started" ist, dann gibt es keine ballots.
-
-Wenn poll.visibility == "manually", dann wird kein ballot-objekt erstellt.
-
-Ansonsten:
-
-Im alten system gibt es pro user und option eine vote. Diese müssen in jeweils
-ein ballot-objekt zusammengefasst werden. Die Votes können über
-old_poll.option_ids.vote_ids gefunden werden. Werte mit identischem user-token
-gehören zusammen.
+For each old option ("old"), the option.content_object_id value has to be a
+`user` collection. Otherwise, @panic. The user_id has to be retrieved from this
+field, and the meeting_user_id associated with it is then looked up in the
+corresponding meeting.
 
 ```
 {
-  id: kann automatisch erstellt werden ich würde nicht die alten ids verwenden,
-  weight: old.weight (muss bei allen votes identisch sein, sonst @panic),
-  split: false,
-  value: Siehe unten,
-  poll_id: old.poll_id,
-  acting_meting_user_id: old.delegated_user_id -> Als meeting_user_id im entsprechenden meeting,
-  represented_meeting_user_id: old.user_id -> Als meeting_user_id im entsprechenden meeting,
+  poll_id: new_poll.id,
+  weight: old.weight,
+  text: NULL,
+  meeting_user_id: meeting_user_id from old.user_id and old.meeting_id
 }
 ```
 
-`poll_ballot/value` sieht wie folgt aus:
-`{"option_id_A":"yes","option_id_B":"abstain"}`. Daher pro option gibt es ein
-Attribut als String. Der Wert wird genauso umgerechnet, wie bei motion: old{"Y":
-"yes", "N": "no", "A": "abstain"} ansonsten @panic.
+#### poll/result
+
+Poll/result is a dict. There is one entry for each old option. The key is
+the poll_option-id created above. The values "yes", "no" and "abstain" are
+adopted as objects.
+
+Example: `{"1":{"yes":"5","no":"1"},"2":{"yes":"1","abstain":"6"},"total_ballots":7}`
+
+Calculation:
+```
+{
+  for each option:
+    option.id: {
+      yes: option.yes -> string,  (skip if 0)
+      no: option.no -> string,  (skip if 0)
+      abstain: option.abstain -> string   (skip if 0)
+    },
+
+  total_ballots: count(all_options.vote_ids) -> number
+}
+```
+
+#### poll_ballot
+
+In the old system for each pair user-option a sepatate `vote` was created. A single
+`poll_ballot` should be generated for each group of the votes with the same
+`user_token`. All of these votes must have the same `weight` - else @panic.
+
+Old votes that can be found via `old_poll.option_ids.vote_ids`.
+
+Calculation (one `poll_ballot` per each `user_token`):
+
+```
+{
+  poll_id: new_poll.id,
+  weight: old.weight (must be same for all),
+  split: false,
+  value: see below,
+  acting_meeting_user_id: meeting_user_id from old.delegated_user_id and poll.meeting,
+  represented_meeting_user_id: meeting_user_id from old.user_id and poll.meeting
+}
+```
+
+Example of `poll_ballot.value`: `{"1":"yes","2":"abstain"}`.
+
+It's a dictionary where each key-value pair represents an old `vote`:
+
+* key: vote.option_id -> should be replaced with the id of the new `poll_option`
+  instances created above
+* value: transformed vote.value:
+      - Y -> yes
+      - N -> no
+      - A -> abstain
+      - else @panic(impossible value)
 
 
-### topic
+## Information that will be lost:
 
-Wird fast identisch wie bei assignment durchgeführt.
-
-Aber als key bei poll/result und config werden nicht die meeting_user_ids
-verwendet, sondern `poll_option.text`.
-
-
-
-## Informationen, die Verloren gehen:
-
-* Kurzlaufend oder langlaufend
-* poll/description, sollte aber nie gesetzt gewesen sein
-* Wahlverzeichet: entitled_users_at_stop. Es wird gerade nur übertragen, wer gewählt hat, aber nicht, wer stimmberechtigt war.
-* Bei kummulativen Wahlen: poll.max_votes_per_option (daher, was die Einstellung war)
-* Global options werden nicht mehr separat aufgeführt, sondern in das Ergebnis mit einberechnet.
-* Poll.valid wurde bisher separat gezählt. In Zukunft muss es berechnet werden. Aus anzahl der votes minus result.invalid
+* poll/backend: long or short
+* poll/description: was not used
+* poll/entitled_users_at_stop: only sata about the actual poll results is
+  being migrated, but not who was entitled to vote
+* For cumulative polls: poll.max_votes_per_option
+* Global options are no longer listed separately, but are included in the result.
+* poll/valid was previously counted separately. In future, it should be
+  calculated by subtracting result.invalid from the total number of votes.
 
 
 ## Einzelvergleich

--- a/Migration.md
+++ b/Migration.md
@@ -498,19 +498,30 @@ It's a dictionary where each key-value pair represents an old `vote`:
   * meeting/poll_candidate_ids
   * meeting/option_ids
   * meeting/vote_ids
+* Fields that were renamed:
+  * meeting/motion_poll_projection_name_order_first -> poll_projection_name_order_first
+  * meeting/motion_poll_projection_max_columns -> poll_projection_max_columns
+* Fields that need to be moved to meeting_poll_default:
+  * meeting/*_poll_ballot_paper_selection -> meeting_poll_default/ballot_paper_selection
+  * meeting/*_poll_ballot_paper_number -> meeting_poll_default/ballot_paper_number
+  * meeting/*_poll_sort_result_by_votes -> meeting_poll_default/sort_result_by_votes
+  * meeting/*_poll_sort_result_by_votes -> meeting_poll_default/sort_result_by_votes
 * Fields should be renamed and values should be changed similarly to poll/type:
-  * meeting/motion_poll_default_type -> meeting/motion_poll_default_visibility
-  * meeting/assignment_poll_default_type -> meeting/assignment_poll_default_visibility
-  * meeting/poll_default_type -> meeting/poll_default_visibility
+  * meeting/*_poll_default_type -> meeting_poll_default/visibility
 * Values should be changed similarly to poll/onehundred_percent_base:
-  * meeting/motion_poll_default_onehundred_percent_base
-  * meeting/assignment_poll_default_onehundred_percent_base
-  * meeting/poll_default_onehundred_percent_base
-* meeting/assignment_poll_default_method:
-  * Y -> selection
-  * N -> selection
-  * YN -> ???
-  * YNA -> ???
+  * meeting/*_poll_default_onehundred_percent_base -> meeting_poll_default/onehundred_percent_base
+* Topic meeting_poll_default/display_chart: pie
+* meeting/assignment_poll_default_method
+  * Y
+    *  meeting_poll_default/method -> selection
+  * N
+    *  meeting_poll_default/method -> selection
+    *  meeting_poll_default/strike_out -> true
+  * YN
+    * meeting_poll_default/method -> rating_approval
+  * YNA
+    * meeting_poll_default/method -> rating_approval
+    * meeting_poll_default/allow_abstain -> true
 
 ### Motion
 

--- a/Migration.md
+++ b/Migration.md
@@ -465,49 +465,142 @@ It's a dictionary where each key-value pair represents an old `vote`:
 * poll/valid was previously counted separately. In future, it should be
   calculated by subtracting result.invalid from the total number of votes.
 
+## Changes in old fields by collection
 
-## Einzelvergleich
+### Group (permissions)
 
-(Dieser Abschnitt ist möglicherweise veraltet. Ich gehe davon aus, dass es ihn
-aufgrund der Beschreibung oben nicht braucht.)
+* group/permissions: poll.can_manage was replaced with 3 separate permissions:
+  * motion.can_manage_polls (existing)
+  * assignment.can_manage_polls (existing)
+  * agenda_item.can_manage_polls (new)
 
-### Alte Felder
+To be discussed: should all the users who previously had `poll.can_manage` get
+all the 3 collection-specific permissions.
 
-* meeting/poll_default_backend was removed. No migration necessary. Just remove the value.
-* motion/option_ids was removed. I think, it can just be removed (ignored) since it has no meaning.
-* poll/description was removed. No migration needed. Was not used before.
-* poll/type was renamed to poll/visibility and the values have changed.
-  * "analog" -> "manually"
-  * "named": Its not clear to me if old "named" values should be "named" in the new system or "open". I think, "open" is ok.
-  * "pseudoanonymous" -> "secret"
-  * "cryptographic": There should be no case. If so, "secret" can be used.
+### Meeting
 
-* poll/backend: was removed. No migration necessary.
-* poll/is_pseudoanonymized: poll/anonymized.
-* poll/pollmethod. Was removed, is now part of poll/config_id.
-* poll/state: The value `published` was removed. polls in this state have to be set to `finished` and the field `poll/published` has to be set to true.
-* poll/min_votes_amount, poll/max_votes_amount, poll/max_votes_per_option, poll/global_yes, poll/global_no, poll/global_abstain are removed. The new field poll/config has to be generated from them.
-* poll/onehundred_percent_base moved to config_id and some options were removed or renamed. YNA -> valid, YN -> yes_no.
-* poll/votesvalid, poll/votesinvalid, poll/votescast where removed. They have to be used to generate the field `poll/result`.
-* poll/entitled_users_at_stop was removed. TODO after the client is done.
-* poll/live_voting_enabled was removed. No migration needed, since there are no ongoing polls at the same time as the migration.
-* poll/live_votes was removed. No migration needed.
-* poll/crypt_key, poll/crypt_signature, poll/votes_raw, poll/votes_signature were removed: No migration needed. There was no case with this values.
-* poll/option_ids, poll/global_option_id was removed: No migration needed. But are necessary to generate `poll/result`.
-* The `option` collection was removed. No migration needed, but necessary to generate `poll/result`.
-* vote/user_token was removed: No migration necessary
-* vote/user_id was renamed to ballot/represented_meeting_user_id.
-* vote/delegated_user_id was renamed to ballot/acting_meeting_user_id.
-* vote/meeting_id was removed. No migration necessary.
+* Fields were removed. No migration necessary:
+  * meeting/motion_poll_default_method
+  * meeting/assignment_poll_default_backend
+  * meeting/poll_default_backend
+  * meeting/poll_candidate_list_ids
+  * meeting/poll_candidate_ids
+  * meeting/option_ids
+  * meeting/vote_ids
+* Fields should be renamed and values should be changed similarly to poll/type:
+  * meeting/motion_poll_default_type -> meeting/motion_poll_default_visibility
+  * meeting/assignment_poll_default_type -> meeting/assignment_poll_default_visibility
+  * meeting/poll_default_type -> meeting/poll_default_visibility
+* Values should be changed similarly to poll/onehundred_percent_base:
+  * meeting/motion_poll_default_onehundred_percent_base
+  * meeting/assignment_poll_default_onehundred_percent_base
+  * meeting/poll_default_onehundred_percent_base
+* meeting/assignment_poll_default_method:
+  * Y -> selection
+  * N -> selection
+  * YN -> ???
+  * YNA -> ???
 
+### Motion
 
-## Permissions
+* Field was removed. No migration necessary:
+  * motion/option_ids
 
-Mit dem neuen System werden auch Permissions angepasst. Hier der Diff:
+### Poll
 
-https://github.com/OpenSlides/openslides-meta/pull/506/changes#diff-028ac608b338b62cdb586060b482ae073373845dd5de19118d2cbd253b597418
+* Fields were removed. No migration necessary:
+  * poll/description
+  * poll/backend
+  * poll/live_votes
+  * poll/entitled_users_at_stop
+  * poll/votesvalid
+  * poll/votesinvalid
+  * poll/votescast
+* poll/is_pseudoanonymized -> poll/anonymized.
+* poll/type -> poll/visibility and the values have changed:
+  * analog -> manually
+  * named -> open
+  * pseudoanonymous -> secret
+  * cryptographic There should be no case. If so, "secret" can be used.
+* poll/onehundred_percent_base -> poll_config_X/onehundred_percent_base and
+  some values have changed:
+  * YN -> yes_no
+  * YNA -> valid
+  * Y -> no_general
+  * N -> no_general (+ poll_config_selection/strike_out: true)
+  * valid: no changes.
+  * cast: no changes.
+  * entitled: no changes.
+  * entitled_present: no changes.
+  * disabled: no changes.
+* poll/state: The value `published` was removed. Published polls have to be migrated:
+  * poll/state -> `finished`.
+  * poll/published -> `true`.
+* Fields were moved to poll_config_X collections, data has to be migrated.
+  Refer to [Migrating the polls](#migrating-the-polls) for more details:
+  * poll/pollmethod
+  * poll/min_votes_amount
+  * poll/max_votes_amount
+  * poll/max_votes_per_option
+  * poll/option_ids
+* Fields were removed, `poll/result` has to be generated from them. Refer to
+  [Migrating the polls](#migrating-the-polls) for more details:
+  * poll/global_yes
+  * poll/global_no
+  * poll/global_abstain
+  * poll/global_option_id
 
-Es wurden neue Rechte eingefügt, die für die Migration nicht gebraucht werden.
-Die einzige migrationsrelevante Änderung ist:
+### Poll_candidate_list
 
-`poll.can_manage` heißt jetzt `agenda_item.can_manage_polls`.
+* The `poll_candidate_list` collection was removed. No migration needed.
+
+### Poll_candidate, option -> poll_option
+
+* Parts `poll_candidate` and `option` were absorbed by the new collection `poll_option`:
+  * poll_option/weight:
+    * option/weight
+    * poll_candidate/weight
+  * poll_option/poll_id:
+    * option/poll_id
+    * poll_candidate_list_id.option_id.poll_id
+  * poll_option/text:
+    * option/text
+    * None
+  * poll_option/meeting_user_id:
+    * if collection of content_object_id == "user" -> meeting_user from
+      option/content_object_id and option/meeting_id
+    * meeting_user from poll_candidate/user_id and
+      poll_candidate.option_id.meeting_id
+
+### Option -> other collections
+
+* The following fields were removed but have to be used in the migration for
+  generating values for generating poll/result:
+  * yes, no and abstain
+  * vote_ids
+
+### Projection
+
+* projection/content was removed. No migration necessary.
+
+### Vote
+
+* The `vote` collection was renamed into `poll_ballot`.
+* Field was removed. No migration necessary:
+  * vote/meeting_id
+* vote/user_token: is used to merge old votes into new ballots
+* vote/user_id -> poll_ballot/represented_meeting_user_id (needs to be
+  generated from user_id and meeting_id).
+* vote/delegated_user_id -> poll_ballot/acting_meeting_user_id (needs to be
+  generated from user_id and meeting_id).
+* vote/option_id: replaced with the direct relation to the poll. Needs
+  migration: vote.option_id.poll_id -> poll_ballot.poll_id.
+
+### User
+
+* Direct relation between `user` and `poll`, `option` and `vote` was replaced
+with relation through the `meeting_user`:
+  * user/poll_voted_ids -> meeting_user/poll_voted_ids
+  * user/option_ids + user/poll_candidate_ids -> meeting_user/poll_option_ids
+  * user/vote_ids -> meeting_user/represented_ballot_ids
+  * user/delegated_vote_ids -> meeting_user/acting_ballot_ids

--- a/Migration.md
+++ b/Migration.md
@@ -488,9 +488,6 @@ It's a dictionary where each key-value pair represents an old `vote`:
 * group/permissions: poll.can_manage -> agenda_item.can_manage_polls (migration
   is needed)
 
-To be discussed: should all the users who previously had `poll.can_manage` get
-all the 3 collection-specific permissions.
-
 ### Meeting
 
 * Fields were removed. No migration necessary:

--- a/Migration.md
+++ b/Migration.md
@@ -502,6 +502,7 @@ It's a dictionary where each key-value pair represents an old `vote`:
   * meeting/motion_poll_projection_name_order_first -> poll_projection_name_order_first
   * meeting/motion_poll_projection_max_columns -> poll_projection_max_columns
 * Fields that need to be moved to meeting_poll_default:
+  * meeting/*_poll_group_ids -> meeting_poll_default/group_ids
   * meeting/*_poll_ballot_paper_selection -> meeting_poll_default/ballot_paper_selection
   * meeting/*_poll_ballot_paper_number -> meeting_poll_default/ballot_paper_number
   * meeting/*_poll_sort_result_by_votes -> meeting_poll_default/sort_result_by_votes

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenSlides Vote Service
 
 The Vote Service is part of the OpenSlides environments. It is responsible for
-the `poll`, `poll_config_X`, `poll_config_option` and `ballot` collections. It
+the `poll`, `poll_config_X`, `poll_option` and `poll_ballot` collections. It
 handles the electronic voting.
 
 The service has no internal state but uses the normal postgres database to save
@@ -16,9 +16,9 @@ With the exception of the vote request, all requests can only be sent by a
 manager. The permission depends on the field `content_object_id` of the
 corresponding poll.
 
-- motions: `motion.can_manage`
-- assignments: `assignment.can_manage`
-- topic: `poll.can_manage`
+- motions: `motion.can_manage_polls`
+- assignments: `assignment.can_manage_polls`
+- topic: `agenda_item.can_manage_polls`
 
 
 ### Create a poll
@@ -90,7 +90,7 @@ creates the `poll/result` field.
 
 The request has two optional attributes: `publish` and `anonymize`. `publish`
 sets the field `poll/state` to `published`. `anonymize` removes all user ids
-from the corresponding `ballot` objects.
+from the corresponding `poll_ballot` objects.
 
 The request can be send many times. It only creates the result the first time.
 `publish` and `anonymize` can be used on a later request.
@@ -105,7 +105,7 @@ request can be used:
 
 `POST /system/vote/poll/{id}/reset`
 
-Reset sets the state back to `created` and removes all `ballot` objects.
+Reset sets the state back to `created` and removes all `poll_ballot` objects.
 
 
 ### Send a ballot
@@ -116,7 +116,7 @@ A vote-request is a post request with the ballot as body. Only logged in users
 can vote. The body has to be valid json.
 
 The service distinguishes between two users on each vote-request. The acting
-user is the request user, that sends the vote-request. The represented user is
+user is the request user that sends the vote-request. The represented user is
 the user, for whom the ballot is sent. Both users can be the same.
 
 The acting user has to be present in the meeting and needs the permission to
@@ -175,7 +175,7 @@ have two different meanings. In future versions, there will probably be
 different features for this two modes.
 
 The value `named` means that the mapping between votes and users is not deleted
-at the end. In a political context, a 'named' poll also means that eligible
+at the end. In a political context, a `named` poll also means that eligible
 voters are called individually, publicly, and one after another, and asked for
 their vote. In the future, a feature could be considered where, for
 `named`-polls, users cannot vote themselves, but instead the manager is guided
@@ -191,8 +191,8 @@ handler.
 
 At the moment, a `secret`-poll is identical to an `open`- or `named`-poll. But
 is handled differently in the autoupdate-service. The field
-`ballot/acting_user_id` and `ballot/represented_user_id` get restricted for
-everybody.
+`poll_ballot/acting_user_id` and `poll_ballot/represented_user_id` get
+restricted for everybody.
 
 In the future, these values will be used for crypto votes. See the entry in the
 [wiki](https://github.com/OpenSlides/OpenSlides/wiki/DE%3AKonzept-geheime-Wahlen-mit-OpenSlides)
@@ -200,8 +200,8 @@ In the future, these values will be used for crypto votes. See the entry in the
 
 ## Poll methods
 
-The values of `method_config`in the poll-create-request, `ballot/value` and
-`poll/result` depend on the field poll method.
+The values of `method_config` in the poll-create-request, `poll_ballot/value`
+and `poll/result` depend on value in field `method` in the poll create request.
 
 The method of a poll can be calculated by looking at the collection-part of the
 generic-relation-field `poll.config_id`.
@@ -209,7 +209,7 @@ generic-relation-field `poll.config_id`.
 
 ### approval
 
-On an approval poll, the users can vote with `yes`, `no` or `abstain`. This is
+In an approval poll, the users can vote with `yes`, `no` or `abstain`. This is
 the usual method to vote on a motion.
 
 
@@ -218,12 +218,12 @@ the usual method to vote on a motion.
 `allow_abstain`: if set to `true`, users are allowed to vote with `abstain`. The
 default is `true`.
 
-`onehundred_percent_base`: Value, that explains, how the 100 % of the poll
-result should be calculated. This value is not needed to calculate the absolue
+`onehundred_percent_base`: Value that explains, how the 100 % of the poll
+result should be calculated. This value is not needed to calculate the absolute
 result, but only to present the relative result in percent.
 
 
-#### ballot/value
+#### poll_ballot/value
 
 Valid ballots look like: `{"value":"yes"}`, `{"value":"no"}` or
 `{"value":"abstain"}`.
@@ -261,16 +261,16 @@ default is no limit.
 The default is `false`.
 
 `onehundred_percent_base`: Value, that explains, how the 100 % of the poll
-result should be calculated. This value is not needed to calculate the absolue
+result should be calculated. This value is not needed to calculate the absolute
 result, but only to present the relative result in percent.
 
 `strike_out`: boolean value. If set, the selected options are interpreted
-negativly and the result is presented accordingly.
+negatively and the result is presented accordingly.
 
 `display_chart`: string value. Tells the client, how to display the poll.
 
 
-#### ballot/value
+#### poll_ballot/value
 
 A ballot is a list of option ids. For example: `{"value":[1]}`.
 
@@ -323,11 +323,11 @@ options. The default is no limit.
 options. The default is no limit.
 
 `onehundred_percent_base`: Value, that explains, how the 100 % of the poll
-result should be calculated. This value is not needed to calculate the absolue
+result should be calculated. This value is not needed to calculate the absolute
 result, but only to present the relative result in percent.
 
 
-#### ballot/value
+#### poll_ballot/value
 
 A ballot is an object/dictionary from the `option_id` as string to the numeric
 score. For example: `{"value":{"1":3, "2":1}}`.
@@ -355,11 +355,11 @@ can give a value like `"Yes"`, `"No"` or `"Abstain"`.
 `allow_abstain`: The same as for `approval`.
 
 `onehundred_percent_base`: Value, that explains, how the 100 % of the poll
-result should be calculated. This value is not needed to calculate the absolue
+result should be calculated. This value is not needed to calculate the absolute
 result, but only to present the relative result in percent.
 
 
-#### ballot/value
+#### poll_ballot/value
 
 A ballot value looks like a combination between `rating_score` and `approval`:
 `{"value":{"1":"yes","2":"abstain"}}`.
@@ -372,9 +372,9 @@ A `rating_approval` result looks like:
 
 This means, that for the option with id `1`, there where 5 ballots with `Yes`,
 one ballot with `No` and no `abstain`. For the option with id `2`, there where
-one `Yes`, 6 `Abstain` and no `No`. There where one invalid ballots.
+one `Yes`, 6 `Abstain` and no `No`. There was one invalid ballot.
 
-A ballot is invalid, if one of its values is invalid. For example a ballot like
+A ballot is invalid if one of its values is invalid. For example a ballot like
 `{"value":{"1":"yes","2":"INVALID-VALUE"}}` is counted as invalid for both
 candidates.
 
@@ -400,7 +400,7 @@ changed for each user. Each user has a default vote weight
 (`user/default_vote_weight`), that can be changed for each meeting
 (`meeting_user/vote_weight`).
 
-This weight is saved (`ballot/weight`) and taken into account when generating
+This weight is saved (`poll_ballot/weight`) and taken into account when generating
 the result.
 
 The weight is not a floating number, but a decimal number. JSON can not
@@ -424,8 +424,8 @@ The attribute `split` says, that vote-split is activated for that ballot, then,
 the `value` attribute is an object/dictionary, where the keys are decimals and the
 values the normal ballot values.
 
-To be valid, each ballot-part has to be valid. If one part is invalid, the hole
-ballot is treated as invalid.
+To be valid, each ballot-part has to be valid. If one part is invalid, the
+whole ballot is treated as invalid.
 
 Vote split is not possible for secret polls.
 


### PR DESCRIPTION
* Updated the docs based on the changes in https://github.com/OpenSlides/openslides-meta/pull/372 and https://github.com/OpenSlides/openslides-meta/pull/532
* Added more details to Übertragung (including the ones discussed personally)
* Translated german parts to english

Questionable parts:
* Were YN and YNA possible for assignment polls? If yes, how should they be migrated in `meeting/assignment_poll_default_method`? Refering to: https://github.com/vkrasnovyd/openslides-vote-service/blob/66534f7fe61bae056acbc81dd8c2ba73add10e7e/Migration.md?plain=1#L505-L509
* Should all the users who previously had `poll.can_manage` get all the 3 collection-specific permissions? Should be documented instead of: https://github.com/vkrasnovyd/openslides-vote-service/blob/66534f7fe61bae056acbc81dd8c2ba73add10e7e/Migration.md?plain=1#L484-L485