### PR TITLE
Adds maximum amount of yes votes to polls

### DIFF
--- a/vote/vote.go
+++ b/vote/vote.go
@@ -765,6 +765,9 @@ func validate(poll dsmodels.Poll, v ballotValue) string {
 		if poll.MaxVotesAmount == 0 {
 			poll.MaxVotesAmount = len(poll.OptionIDs)
 		}
+		if poll.MaxYesVotesAmount == 0 {
+			poll.MaxYesVotesAmount = len(poll.OptionIDs)
+		}
 		switch v.Type() {
 		case ballotValueString:
 			// The user answered with Y, N or A (or another invalid string).
@@ -788,6 +791,12 @@ func validate(poll dsmodels.Poll, v ballotValue) string {
 					return fmt.Sprintf("Data for option %d does not fit the poll method.", optionID)
 				}
 			}
+
+			var yes_votes = countYesVotes(v)
+			if yes_votes > poll.MaxYesVotesAmount {
+				return fmt.Sprintf("The amount of yes votes must not exceed %d", poll.MaxYesVotesAmount)
+			}
+
 			return voteIsValid
 
 		default:
@@ -869,4 +878,15 @@ func equalElement(g1, g2 []int) bool {
 		}
 	}
 	return false
+}
+
+// counts the amount of yes votes in a ballot
+func countYesVotes(vote ballotValue) int {
+	var amount int
+	for _, yna := range vote.optionYNA {
+		if yna == "Y" {
+			amount++
+		}
+	}
+	return amount
 }


### PR DESCRIPTION
This PR adds the functionallity behind the maxmimum amount of yes votes to the votes service. It is only relevant if the poll is YN or YNA. If the user supplied more yes votes then allowed, the backend will reject the ballot.

This PR needs this one to be merged first: https://github.com/OpenSlides/openslides-go/pull/283
It is related to this overarching PR: https://github.com/OpenSlides/OpenSlides/pull/7134

Note: As the default for max_yes_votes_amount is 1 and setting the value to the amount of candidates happens in the frontend this probably also depends on this PR https://github.com/OpenSlides/openslides-client/pull/6309 to not break the poll functionallity.