### PR TITLE
Validate poll result

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ manually.
 
 Manual polls behave differently. When created, the field `poll/state` is set to
 `finished`. The poll result can be set either with the create request or with an
-update request. The server does not validate the field `poll/result`, but
-accepts any string.
+update request. The server only makes sure, that the field `poll/result` is
+valid json.
 
 vote-requests are not possible. A finalize-request is possible, but only to set
 the `poll/published` field. A reset-request sets/leaves the state at `finished`.

--- a/vote/vote.go
+++ b/vote/vote.go
@@ -415,7 +415,7 @@ type updateInput struct {
 	Visibility        string              `json:"visibility"`
 	EntitledGroupIDs  []int               `json:"entitled_group_ids"`
 	LiveVotingEnabled dsfetch.Maybe[bool] `json:"live_voting_enabled"`
-	Result            []byte              `json:"result"`
+	Result            json.RawMessage     `json:"result"`
 	AllowVoteSplit    dsfetch.Maybe[bool] `json:"allow_vote_split"`
 }
 

--- a/vote/vote.go
+++ b/vote/vote.go
@@ -415,14 +415,14 @@ type updateInput struct {
 	Visibility        string              `json:"visibility"`
 	EntitledGroupIDs  []int               `json:"entitled_group_ids"`
 	LiveVotingEnabled dsfetch.Maybe[bool] `json:"live_voting_enabled"`
-	Result            json.RawMessage     `json:"result"`
+	Result            []byte              `json:"result"`
 	AllowVoteSplit    dsfetch.Maybe[bool] `json:"allow_vote_split"`
 }
 
 func parseUpdateInput(r io.Reader, poll dsmodels.Poll, electronicVotingEnabled bool) (updateInput, error) {
 	var ui updateInput
 	if err := json.NewDecoder(r).Decode(&ui); err != nil {
-		return updateInput{}, fmt.Errorf("decoding update input: %w", err)
+		return updateInput{}, MessageError(ErrInvalid, "Request body is not a valid json object.")
 	}
 
 	if poll.Visibility == "manually" {

--- a/vote/vote_test.go
+++ b/vote/vote_test.go
@@ -553,6 +553,23 @@ func TestManually(t *testing.T) {
 				t.Errorf("State == %s. A manually poll has to be in state finished after a reset", poll.State)
 			}
 		})
+
+		t.Run("Invalid json", func(t *testing.T) {
+			body := `{
+				"result": {THIS IS NOT JSON}
+			}`
+
+			err := service.Update(ctx, 1, 5, strings.NewReader(body))
+
+			if err == nil {
+				t.Fatalf("Expected an error on invalid json. Got non")
+			}
+
+			if !errors.Is(err, vote.ErrInvalid) {
+				t.Errorf("Update with invalid json returned an unexpected error: %v", err)
+			}
+
+		})
 	})
 }
 


### PR DESCRIPTION
The server already validated the result field by accident. The request body has to be valid json, so the result field also has to be valid json.

I changed the README, added a test and changed the error type on the update-request from 500 to 400. On create-requests, it already was a 400.